### PR TITLE
Update TextNowBot and add Playwright asynchronous API support

### DIFF
--- a/.github/workflows/cd_prod.yml
+++ b/.github/workflows/cd_prod.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install semantic-version setuptools wheel twine
+        pip install requests semantic-version setuptools wheel twine
     - name: Resolve target version
       run: |
         TARGET_VERSION=${TARGET_VERSION#refs/*/v}

--- a/.github/workflows/cd_staging.yml
+++ b/.github/workflows/cd_staging.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install semantic-version setuptools wheel twine
+        pip install requests semantic-version setuptools wheel twine
     - name: Resolve target version
       run: echo TARGET_VERSION=$(python scripts/resolve_target_version.py) >> $GITHUB_ENV
     - name: Build package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,6 @@ on:
     branches: main
   workflow_dispatch:
 
-env:
-  TARGET_NAME: textnow-bot
-  TARGET_VERSION: 1.0.0
-
 jobs:
   lint:
     name: Run linter

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ import json
 from pathlib import Path
 
 from playwright.async_api import async_playwright
-from textnow_bot import TextNowBot
+from textnow_bot import AsyncTextNowBot
 
 
 async def run(playwright):
@@ -101,15 +101,15 @@ async def run(playwright):
         browser = await playwright.firefox.launch()
         page = await browser.new_page()
 
-        bot = TextNowBot(page)
+        bot = AsyncTextNowBot(page)
 
         if cookies_path.exists():
             cookies = json.loads(cookies_path.read_text())
-            await bot.async_log_in(cookies)
+            await bot.log_in(cookies)
         else:
-            await bot.async_log_in(None, username, password)
+            await bot.log_in(None, username, password)
 
-        await bot.async_send_message(recipient, message)
+        await bot.send_message(recipient, message)
 
         cookies_path.write_text(json.dumps(await bot.cookies))
 

--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ asyncio.run(main())
 ### Secrets
 
 ```yaml
-PYPI_USERNAME: "__token__"
+PYPI_USERNAME: __token__
 PYPI_PASSWORD: "********"
 
-TESTPYPI_USERNAME: "__token__"
+TESTPYPI_USERNAME: __token__
 TESTPYPI_PASSWORD: "********"
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-playwright==0.171.1
+playwright==1.8.0a1

--- a/textnow_bot.py
+++ b/textnow_bot.py
@@ -41,7 +41,25 @@ class TextNowBot:
 
         self._is_logged_in = True
 
-    async def async_log_in(self, cookies=None, username=None, password=None):
+    def send_message(self, recipient, message):
+        if not self.is_logged_in:
+            raise Exception("authentication failed")
+
+        logging.info("Sending message...")
+
+        self.page.goto(f"{TEXTNOW_URL}/messaging")
+        self.page.click("#newText")
+
+        self.page.type(".newConversationTextField", recipient)
+        self.page.press(".newConversationTextField", "Enter")
+
+        self.page.type("#text-input", message)
+        self.page.press("#text-input", "Enter")
+        self.page.wait_for_timeout(500)
+
+
+class AsyncTextNowBot(TextNowBot):
+    async def log_in(self, cookies=None, username=None, password=None):
         if cookies:
             logging.info("Logging in with cookies...")
             await self.page.context.add_cookies(cookies)
@@ -65,23 +83,7 @@ class TextNowBot:
 
         self._is_logged_in = True
 
-    def send_message(self, recipient, message):
-        if not self.is_logged_in:
-            raise Exception("authentication failed")
-
-        logging.info("Sending message...")
-
-        self.page.goto(f"{TEXTNOW_URL}/messaging")
-        self.page.click("#newText")
-
-        self.page.type(".newConversationTextField", recipient)
-        self.page.press(".newConversationTextField", "Enter")
-
-        self.page.type("#text-input", message)
-        self.page.press("#text-input", "Enter")
-        self.page.wait_for_timeout(500)
-
-    async def async_send_message(self, recipient, message):
+    async def send_message(self, recipient, message):
         if not self.is_logged_in:
             raise Exception("authentication failed")
 

--- a/textnow_bot.py
+++ b/textnow_bot.py
@@ -41,6 +41,30 @@ class TextNowBot:
 
         self._is_logged_in = True
 
+    async def async_log_in(self, cookies=None, username=None, password=None):
+        if cookies:
+            logging.info("Logging in with cookies...")
+            await self.page.context.add_cookies(cookies)
+            await self.page.goto(f"{TEXTNOW_URL}/login", wait_until="networkidle")
+        elif username and password:
+            logging.info("Logging in with account credentials...")
+            await self.page.context.clear_cookies()
+
+            await self.page.goto(f"{TEXTNOW_URL}/login")
+            await self.page.type("#txt-username", username)
+            await self.page.type("#txt-password", password)
+            await self.page.click("#btn-login")
+            await self.page.wait_for_load_state("networkidle")
+
+            await self.page.context.add_cookies([PERMISSION_COOKIE])
+        else:
+            raise Exception("missing account credentials")
+
+        if "/messaging" not in self.page.url:
+            raise Exception("authentication failed")
+
+        self._is_logged_in = True
+
     def send_message(self, recipient, message):
         if not self.is_logged_in:
             raise Exception("authentication failed")
@@ -56,3 +80,19 @@ class TextNowBot:
         self.page.type("#text-input", message)
         self.page.press("#text-input", "Enter")
         self.page.wait_for_timeout(500)
+
+    async def async_send_message(self, recipient, message):
+        if not self.is_logged_in:
+            raise Exception("authentication failed")
+
+        logging.info("Sending message...")
+
+        await self.page.goto(f"{TEXTNOW_URL}/messaging")
+        await self.page.click("#newText")
+
+        await self.page.type(".newConversationTextField", recipient)
+        await self.page.press(".newConversationTextField", "Enter")
+
+        await self.page.type("#text-input", message)
+        await self.page.press("#text-input", "Enter")
+        await self.page.wait_for_timeout(500)

--- a/textnow_bot.py
+++ b/textnow_bot.py
@@ -5,34 +5,46 @@ PERMISSION_COOKIE = {"name": "PermissionPriming", "value": "-1", "url": TEXTNOW_
 
 
 class TextNowBot:
-    def __init__(self, page, cookies=None, username=None, password=None):
+    def __init__(self, page):
         self.page = page
+        self._is_logged_in = False
 
-        if cookies:
-            logging.info("Logging in with cookies...")
-            page.context.addCookies(cookies)
-            page.goto(f"{TEXTNOW_URL}/login", waitUntil="networkidle")
-        elif username and password:
-            logging.info("Logging in with account info...")
-            page.context.clearCookies()
+    @property
+    def is_logged_in(self):
+        return self._is_logged_in
 
-            page.goto(f"{TEXTNOW_URL}/login")
-            page.type("#txt-username", username)
-            page.type("#txt-password", password)
-            page.click("#btn-login")
-            page.waitForNavigation()
-
-            page.context.addCookies([PERMISSION_COOKIE])
-        else:
-            raise Exception("missing authentication info")
-
-        if "/messaging" not in page.url:
-            raise Exception("authentication failed")
-
-    def get_cookies(self):
+    @property
+    def cookies(self):
         return self.page.context.cookies(TEXTNOW_URL)
 
+    def log_in(self, cookies=None, username=None, password=None):
+        if cookies:
+            logging.info("Logging in with cookies...")
+            self.page.context.add_cookies(cookies)
+            self.page.goto(f"{TEXTNOW_URL}/login", wait_until="networkidle")
+        elif username and password:
+            logging.info("Logging in with account credentials...")
+            self.page.context.clear_cookies()
+
+            self.page.goto(f"{TEXTNOW_URL}/login")
+            self.page.type("#txt-username", username)
+            self.page.type("#txt-password", password)
+            self.page.click("#btn-login")
+            self.page.wait_for_load_state("networkidle")
+
+            self.page.context.add_cookies([PERMISSION_COOKIE])
+        else:
+            raise Exception("missing account credentials")
+
+        if "/messaging" not in self.page.url:
+            raise Exception("authentication failed")
+
+        self._is_logged_in = True
+
     def send_message(self, recipient, message):
+        if not self.is_logged_in:
+            raise Exception("authentication failed")
+
         logging.info("Sending message...")
 
         self.page.goto(f"{TEXTNOW_URL}/messaging")
@@ -43,4 +55,4 @@ class TextNowBot:
 
         self.page.type("#text-input", message)
         self.page.press("#text-input", "Enter")
-        self.page.waitForTimeout(500)
+        self.page.wait_for_timeout(500)


### PR DESCRIPTION
This PR updates TextNowBot to use the new Playwright 1.8.0a1 syntax, and adds asynchronous API support. Instead of making a duplicate class for asynchronous operation, I have prefixed asynchronous methods with `async_` so that users are aware of the different method implementations.

I have updated the snippets in the README.md to include cookie persistence, and added an asynchronous snippet.

Closes #1